### PR TITLE
Remove dynamic version referencing on POM in user manual template

### DIFF
--- a/docs/06-documentation-and-release-notes/files/user-manual.adoc
+++ b/docs/06-documentation-and-release-notes/files/user-manual.adoc
@@ -86,10 +86,6 @@ For Maven dependency management, include this XML snippet in your `pom.xml` file
 </dependency>
 ----
 
-Inside the `<version>` tags, put the desired version number, the word `RELEASE` for the latest release, or `SNAPSHOT` for the latest available version. The available versions are:
-
-* *x.y.z*
-
 
 [[configure]]
 == To Configure the Connector


### PR DESCRIPTION
Once a new version of the connector is released, if the Mule app's POM references the latest `RELEASE` version, the Maven build or app in runtime might fail. Also this apparently doesn't work in Maven 3.

[Thread in Stack Overflow](https://stackoverflow.com/questions/30571/how-do-i-tell-maven-to-use-the-latest-version-of-a-dependency)
Snippet of [Maven doc](https://cwiki.apache.org/confluence/display/MAVEN/Maven+3.x+Compatibility+Notes#Maven3.xCompatibilityNotes-PluginMetaversionResolution):

> **Plugin Metaversion Resolution**
> Internally, Maven 2.x used the special version markers `RELEASE` and `LATEST` to support automatic plugin version resolution. These metaversions were also recognized in the `<version>` element for a `<plugin>` declaration. For the sake of reproducible builds, Maven 3.x no longer supports usage of these metaversions in the POM. As a result, users will need to replace occurrences of these metaversions with a concrete version.
>